### PR TITLE
feat: support `/` in ref and provide switchBranches #22

### DIFF
--- a/extensions/github1s/package.json
+++ b/extensions/github1s/package.json
@@ -13,7 +13,7 @@
     "onCommand:github1s.validate-token",
     "onCommand:github1s.update-token",
     "onCommand:github1s.clear-token",
-    "onCommand:github1s.get-current-ref",
+    "onCommand:github1s.get-current-authority",
     "onCommand:github1s.switch-branch",
     "onCommand:github1s.switch-tag",
     "onView:github1s"

--- a/extensions/github1s/package.json
+++ b/extensions/github1s/package.json
@@ -13,7 +13,9 @@
     "onCommand:github1s.validate-token",
     "onCommand:github1s.update-token",
     "onCommand:github1s.clear-token",
-    "onCommand:github1s.get-github-branches",
+    "onCommand:github1s.get-current-ref",
+    "onCommand:github1s.switch-branch",
+    "onCommand:github1s.switch-tag",
     "onView:github1s"
   ],
   "browser": "./dist/extension",
@@ -53,6 +55,16 @@
       {
         "command": "github1s.clear-token",
         "title": "Clear Current GitHub OAuth Token",
+        "category": "GitHub1s"
+      },
+      {
+        "command": "github1s.switch-branch",
+        "title": "Switch to Another Branch",
+        "category": "GitHub1s"
+      },
+      {
+        "command": "github1s.switch-tag",
+        "title": "Switch to Another Tag",
         "category": "GitHub1s"
       }
     ]

--- a/extensions/github1s/src/api.ts
+++ b/extensions/github1s/src/api.ts
@@ -20,15 +20,6 @@ export const isGraphQLEnabled = () => {
 	return hasValidToken() && ENABLE_GRAPHQL;
 };
 
-export const parseUri = (uri: vscode.Uri): UriState => {
-	const [owner, repo] = (uri.authority || '').split('+').filter(Boolean);
-	return {
-		owner,
-		repo,
-		path: uri.path,
-	};
-};
-
 const handleRequestError = (error: RequestError) => {
 	if (error instanceof RequestRateLimitError) {
 		if (!error.token) {

--- a/extensions/github1s/src/api.ts
+++ b/extensions/github1s/src/api.ts
@@ -4,8 +4,8 @@
  */
 
 import * as vscode from 'vscode';
-import { getBranches } from './github-api-gql';
-import { hasValidToken, splitPathByBranchName, getNormalizedPath, reuseable } from './util';
+// import { getBranches } from './github-api-gql';
+import { hasValidToken } from './util';
 import { fetch, RequestError, RequestRateLimitError, RequestInvalidTokenError, RequestNotFoundError, throttledReportNetworkError } from './util/fetch';
 
 export const ENABLE_GRAPHQL: boolean = true;
@@ -13,30 +13,20 @@ export const ENABLE_GRAPHQL: boolean = true;
 export interface UriState {
 	owner: string;
 	repo: string;
-	branch: string;
 	path: string;
-	uri: vscode.Uri
 }
 
 export const isGraphQLEnabled = () => {
 	return hasValidToken() && ENABLE_GRAPHQL;
 };
 
-export const parseUri = (uri: vscode.Uri): Promise<UriState> => {
-	const [owner, repo, pathname] = (uri.authority || '').split('+').filter(Boolean);
-	return getGitHubBranches(owner, repo)
-		.then(
-			branchNames => {
-				const [branch] = splitPathByBranchName(pathname, branchNames);
-				return {
-					owner,
-					repo,
-					branch,
-					path: getNormalizedPath(uri.path, branch),
-					uri,
-				};
-			}
-		);
+export const parseUri = (uri: vscode.Uri): UriState => {
+	const [owner, repo] = (uri.authority || '').split('+').filter(Boolean);
+	return {
+		owner,
+		repo,
+		path: uri.path,
+	};
 };
 
 const handleRequestError = (error: RequestError) => {
@@ -58,13 +48,13 @@ const handleRequestError = (error: RequestError) => {
 	throw vscode.FileSystemError.Unavailable(error.message || 'Unknown Error Occurred When Request To GitHub');
 };
 
-export const readGitHubDirectory = (state: UriState) => {
-	return fetch(`https://api.github.com/repos/${state.owner}/${state.repo}/git/trees/${state.branch}${state.path.replace(/^\//, ':')}`)
+export const readGitHubDirectory = (owner: string, repo: string, ref: string, path: string) => {
+	return fetch(`https://api.github.com/repos/${owner}/${repo}/git/trees/${ref}${path.replace(/^\//, ':')}`)
 		.catch(handleRequestError);
 };
 
-export const readGitHubFile = (state: UriState, fileSha: string) => {
-	return fetch(`https://api.github.com/repos/${state.owner}/${state.repo}/git/blobs/${fileSha}`)
+export const readGitHubFile = (owner: string, repo: string, fileSha: string) => {
+	return fetch(`https://api.github.com/repos/${owner}/${repo}/git/blobs/${fileSha}`)
 		.catch(handleRequestError);
 };
 
@@ -82,25 +72,33 @@ export const validateToken = (token: string) => {
 	});
 };
 
-const branchNameCache = new Map();
-
-export const fetchGitHubBranches = (owner: string, repo: string) => {
-	const key = owner + '/' + repo;
-	if (branchNameCache.has(key)) {
-		return Promise.resolve(branchNameCache.get(key));
-	}
-	return fetch(`https://api.github.com/repos/${owner}/${repo}/branches`)
-		.then(res => {
-			const names = res.map(x => x.name);
-			branchNameCache.set(key, names);
-			return names;
+export const getGithubBranches = (owner: string, repo: string) => {
+	return fetch(`https://api.github.com/repos/${owner}/${repo}/branches?per_page=100`)
+		.then(branches => {
+			// TODO: only no more than 200 branches are supported
+			if (branches.length === 100) {
+				return fetch(`https://api.github.com/repos/${owner}/${repo}/branches?per_page=100&page=2`).then(otherBranches => [...branches, ...otherBranches]);
+			}
+			return branches;
 		})
 		.catch(handleRequestError);
 };
 
-export const getGitHubBranches = (owner: string, repo: string) => {
-	if (isGraphQLEnabled()) {
-		return getBranches(owner, repo);
-	}
-	return fetchGitHubBranches(owner, repo);
+export const getGithubTags = (owner: string, repo: string) => {
+	return fetch(`https://api.github.com/repos/${owner}/${repo}/tags?per_page=100`)
+		.then(tags => {
+			// TODO: only no more than 200 tags are supported
+			if (tags.length === 100) {
+				return fetch(`https://api.github.com/repos/${owner}/${repo}/tags?per_page=100&page=2`).then(otherTags => [...tags, ...otherTags]);
+			}
+			return tags;
+		})
+		.catch(handleRequestError);
 };
+
+// export const getGitHubBranches = (owner: string, repo: string) => {
+// 	if (isGraphQLEnabled()) {
+// 		return getBranches(owner, repo);
+// 	}
+// 	return getGithubBranches(owner, repo);
+// };

--- a/extensions/github1s/src/commands.ts
+++ b/extensions/github1s/src/commands.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode';
-import { getExtensionContext, getRepositoryBranches, getRepositoryTags, getCurrentRef, changeCurrentRef } from './util';
+import { getExtensionContext, getRepositoryBranches, getRepositoryTags, getCurrentRef, getCurrentAuthority, changeCurrentRef } from './util';
 import { validateToken } from './api';
 
 export const commandValidateToken = (silent: boolean = false) => {
@@ -65,7 +65,7 @@ export const commandClearToken = (silent: boolean = false) => {
 	});
 };
 
-export const commandGetCurrentRef = (): Promise<string> => getCurrentRef();
+export const commandGetCurrentAuthority = (): Promise<string> => getCurrentAuthority();
 
 export const commandSwitchBranch = () => {
 	return Promise.all([getRepositoryBranches(), getCurrentRef()]).then(([repositoryBranches, currentRef]) => (

--- a/extensions/github1s/src/commands.ts
+++ b/extensions/github1s/src/commands.ts
@@ -4,8 +4,8 @@
  */
 
 import * as vscode from 'vscode';
-import { getExtensionContext } from './util';
-import { getGitHubBranches, validateToken } from './api';
+import { getExtensionContext, getRepositoryBranches, getRepositoryTags, getCurrentRef, changeCurrentRef } from './util';
+import { validateToken } from './api';
 
 export const commandValidateToken = (silent: boolean = false) => {
 	const context = getExtensionContext();
@@ -65,8 +65,24 @@ export const commandClearToken = (silent: boolean = false) => {
 	});
 };
 
-export const commandGetGitHubBranches = (url: string) => {
-	const { pathname } = new URL(url);
-	const [ owner = 'conwnet', repo = 'github1s' ] = pathname.split(/\/|%2F/g).filter(Boolean);
-	return getGitHubBranches(owner, repo);
+export const commandGetCurrentRef = (): Promise<string> => getCurrentRef();
+
+export const commandSwitchBranch = () => {
+	return Promise.all([getRepositoryBranches(), getCurrentRef()]).then(([repositoryBranches, currentRef]) => (
+		vscode.window.showQuickPick(repositoryBranches.map(item => item.name), { placeHolder: currentRef }).then((newRef: string) => {
+			return newRef && changeCurrentRef(newRef).then((newRef) => {
+				vscode.window.showInformationMessage(`Switch to branch: ${newRef}`);
+			});
+		})
+	));
+};
+
+export const commandSwitchTag = () => {
+	return Promise.all([getRepositoryTags(), getCurrentRef()]).then(([repositoryBranches, currentRef]) => (
+		vscode.window.showQuickPick(repositoryBranches.map(item => item.name), { placeHolder: currentRef }).then((newRef: string) => {
+			return newRef && changeCurrentRef(newRef).then((newRef) => {
+				vscode.window.showInformationMessage(`Switch to branch: ${newRef}`);
+			});
+		})
+	));
 };

--- a/extensions/github1s/src/extension.ts
+++ b/extensions/github1s/src/extension.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { GitHub1sFS } from './github1sfs';
 import { SettingsView } from './settings-view';
 import { setExtensionContext } from './util';
-import { commandUpdateToken, commandValidateToken, commandClearToken, commandSwitchBranch, commandSwitchTag, commandGetCurrentRef } from './commands';
+import { commandUpdateToken, commandValidateToken, commandClearToken, commandSwitchBranch, commandSwitchTag, commandGetCurrentAuthority } from './commands';
 
 export function activate(context: vscode.ExtensionContext) {
 	setExtensionContext(context);
@@ -18,7 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('github1s.validate-token', commandValidateToken));
 	context.subscriptions.push(vscode.commands.registerCommand('github1s.update-token', commandUpdateToken));
 	context.subscriptions.push(vscode.commands.registerCommand('github1s.clear-token', commandClearToken));
-	context.subscriptions.push(vscode.commands.registerCommand('github1s.get-current-ref', commandGetCurrentRef));
+	context.subscriptions.push(vscode.commands.registerCommand('github1s.get-current-authority', commandGetCurrentAuthority));
 	context.subscriptions.push(vscode.commands.registerCommand('github1s.switch-branch', commandSwitchBranch));
 	context.subscriptions.push(vscode.commands.registerCommand('github1s.switch-tag', commandSwitchTag));
 }

--- a/extensions/github1s/src/extension.ts
+++ b/extensions/github1s/src/extension.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { GitHub1sFS } from './github1sfs';
 import { SettingsView } from './settings-view';
 import { setExtensionContext } from './util';
-import { commandUpdateToken, commandValidateToken, commandClearToken, commandGetGitHubBranches } from './commands';
+import { commandUpdateToken, commandValidateToken, commandClearToken, commandSwitchBranch, commandSwitchTag, commandGetCurrentRef } from './commands';
 
 export function activate(context: vscode.ExtensionContext) {
 	setExtensionContext(context);
@@ -18,5 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('github1s.validate-token', commandValidateToken));
 	context.subscriptions.push(vscode.commands.registerCommand('github1s.update-token', commandUpdateToken));
 	context.subscriptions.push(vscode.commands.registerCommand('github1s.clear-token', commandClearToken));
-	context.subscriptions.push(vscode.commands.registerCommand('github1s.get-github-branches', commandGetGitHubBranches));
+	context.subscriptions.push(vscode.commands.registerCommand('github1s.get-current-ref', commandGetCurrentRef));
+	context.subscriptions.push(vscode.commands.registerCommand('github1s.switch-branch', commandSwitchBranch));
+	context.subscriptions.push(vscode.commands.registerCommand('github1s.switch-tag', commandSwitchTag));
 }

--- a/extensions/github1s/src/github1sfs.ts
+++ b/extensions/github1s/src/github1sfs.ts
@@ -15,7 +15,7 @@ import {
 	FileType,
 	Uri,
 } from 'vscode';
-import { noop, reuseable } from './util';
+import { noop, reuseable, getCurrentRef } from './util';
 import { parseUri, readGitHubDirectory, readGitHubFile, UriState, isGraphQLEnabled } from './api';
 import { apolloClient } from './client';
 import { githubObjectQuery } from './github-api-gql';
@@ -105,7 +105,7 @@ export class GitHub1sFS implements FileSystemProvider, Disposable {
 	static scheme = 'github1s';
 	private readonly disposable: Disposable;
 	private _emitter = new EventEmitter<FileChangeEvent[]>();
-	private root: Directory = null;
+	private root: Map<string, Directory | File> = new Map();
 
 	onDidChangeFile: Event<FileChangeEvent[]> = this._emitter.event;
 
@@ -120,12 +120,15 @@ export class GitHub1sFS implements FileSystemProvider, Disposable {
 	}
 
 	// --- lookup
-	private async _lookup(state: UriState, silent: boolean): Promise<Entry | undefined> {
-		if (!this.root) {
-			this.root = new Directory(state.uri.with({ path: '/' }), '');
+	private async _lookup(uri: Uri, silent: false): Promise<Entry>;
+	private async _lookup(uri: Uri, silent: boolean): Promise<Entry | undefined>;
+	private async _lookup(uri: Uri, silent: boolean): Promise<Entry | undefined> {
+		let parts = uri.path.split('/').filter(Boolean);
+		let currentRef = await getCurrentRef();
+		if (!this.root.get(currentRef)) {
+			this.root.set(currentRef, new Directory(uri.with({ path: '/' }), ''));
 		}
-		let entry: Entry = this.root;
-		let parts = state.path.split('/').filter(Boolean);
+		let entry = this.root.get(currentRef);
 		for (const part of parts) {
 			let child: Entry | undefined;
 			if (entry instanceof Directory) {
@@ -136,7 +139,7 @@ export class GitHub1sFS implements FileSystemProvider, Disposable {
 			}
 			if (!child) {
 				if (!silent) {
-					throw FileSystemError.FileNotFound(state.uri);
+					throw FileSystemError.FileNotFound(uri);
 				} else {
 					return undefined;
 				}
@@ -146,23 +149,23 @@ export class GitHub1sFS implements FileSystemProvider, Disposable {
 		return entry;
 	}
 
-	private async _lookupAsDirectory(state: UriState, silent: boolean): Promise<Directory> {
-		const entry = await this._lookup(state, silent);
+	private async _lookupAsDirectory(uri: Uri, silent: boolean): Promise<Directory> {
+		const entry = await this._lookup(uri, silent);
 		if (entry instanceof Directory) {
 			return entry;
 		}
 		if (!silent) {
-			throw FileSystemError.FileNotADirectory(state.uri);
+			throw FileSystemError.FileNotADirectory(uri);
 		}
 	}
 
-	private async _lookupAsFile(state: UriState, silent: boolean): Promise<File> {
-		const entry = await this._lookup(state, silent);
+	private async _lookupAsFile(uri: Uri, silent: boolean): Promise<File> {
+		const entry = await this._lookup(uri, silent);
 		if (entry instanceof File) {
 			return entry;
 		}
 		if (!silent) {
-			throw FileSystemError.FileIsADirectory(state.uri);
+			throw FileSystemError.FileIsADirectory(uri);
 		}
 	}
 
@@ -171,76 +174,73 @@ export class GitHub1sFS implements FileSystemProvider, Disposable {
 	}
 
 	stat(uri: Uri): FileStat | Thenable<FileStat> {
-		return parseUri(uri).then(
-			state => this._lookup(state, false)
-		);
+		return this._lookup(uri, false);
 	}
 
 	readDirectory = reuseable((uri: Uri): [string, FileType][] | Thenable<[string, FileType][]> => {
 		if (!uri.authority) {
 			throw FileSystemError.FileNotFound(uri);
 		}
-		return parseUri(uri)
-			.then((state) => {
-				return this._lookupAsDirectory(state, false).then(parent => {
-					if (parent.entries !== null) {
-						return parent.getNameTypePairs();
-					}
+		return this._lookupAsDirectory(uri, false).then(parent => {
+			if (parent.entries !== null) {
+				return parent.getNameTypePairs();
+			}
 
-					if (isGraphQLEnabled()) {
-						const directory = state.path.substring(1);
-						return apolloClient.query({
-							query: githubObjectQuery, variables: {
-								owner: state.owner,
-								repo: state.repo,
-								expression: `${state.branch}:${directory}`
+			if (isGraphQLEnabled()) {
+				return getCurrentRef().then(ref => {
+					const state: UriState = parseUri(uri);
+					const directory = state.path.substring(1);
+					return apolloClient.query({
+						query: githubObjectQuery, variables: {
+							owner: state.owner,
+							repo: state.repo,
+							expression: `${ref}:${directory}`
+						}
+					})
+						.then((response) => {
+							const entries = response.data?.repository?.object?.entries;
+							if (!entries) {
+								throw FileSystemError.FileNotADirectory(uri);
 							}
-						})
-							.then((response) => {
-								const entries = response.data?.repository?.object?.entries;
-								if (!entries) {
-									throw FileSystemError.FileNotADirectory(uri);
-								}
-								parent.entries = entriesToMap(entries, uri);
-								return parent.getNameTypePairs();
-							});
-					}
-					return readGitHubDirectory(state).then(data => {
-						parent.entries = new Map<string, Entry>();
-						return data.tree.map((item: any) => {
-							const fileType: FileType = item.type === 'tree' ? FileType.Directory : FileType.File;
-							parent.entries.set(
-								item.path, fileType === FileType.Directory
-								? new Directory(uri, item.path, { sha: item.sha })
-								: new File(uri, item.path, { sha: item.sha, size: item.size })
-							);
-							return [item.path, fileType];
+							parent.entries = entriesToMap(entries, uri);
+							return parent.getNameTypePairs();
 						});
-					});
 				});
 			}
-			);
+			const [owner, repo] = uri.authority.split('+');
+			return getCurrentRef().then(ref => readGitHubDirectory(owner, repo, ref, uri.path).then(data => {
+				parent.entries = new Map<string, Entry>();
+				return data.tree.map((item: any) => {
+					const fileType: FileType = item.type === 'tree' ? FileType.Directory : FileType.File;
+					parent.entries.set(
+						item.path, fileType === FileType.Directory
+						? new Directory(uri, item.path, { sha: item.sha })
+						: new File(uri, item.path, { sha: item.sha, size: item.size })
+					);
+					return [item.path, fileType];
+				});
+			}));
+		});
 	}, (uri: Uri) => uri.toString());
 
 	readFile = reuseable((uri: Uri): Uint8Array | Thenable<Uint8Array> => {
 		if (!uri.authority) {
 			throw FileSystemError.FileNotFound(uri);
 		}
-		return parseUri(uri).then(state => {
-			return this._lookupAsFile(state, false).then(file => {
-				if (file.data !== null) {
-					return file.data;
-				}
+		return this._lookupAsFile(uri, false).then(file => {
+			if (file.data !== null) {
+				return file.data;
+			}
 
-				/**
-				 * Below code will only be triggered in two cases:
-				 *   1. The GraphQL query is disabled
-				 *   2. The GraphQL query is enabled, but the blob/file is binary
-				 */
-				return readGitHubFile(state, file.sha).then(blob => {
-					file.data = decodeBase64(blob.content);
-					return file.data;
-				});
+			/**
+			 * Below code will only be triggered in two cases:
+			 *   1. The GraphQL query is disabled
+			 *   2. The GraphQL query is enabled, but the blob/file is binary
+			 */
+			const [owner, repo] = uri.authority.split('+');
+			return readGitHubFile(owner, repo, file.sha).then(blob => {
+				file.data = decodeBase64(blob.content);
+				return file.data;
 			});
 		});
 	}, (uri: Uri) => uri.toString());

--- a/extensions/github1s/src/util/context.ts
+++ b/extensions/github1s/src/util/context.ts
@@ -21,3 +21,5 @@ export const getOAuthToken = () => {
 };
 
 export const hasValidToken = () => getOAuthToken() !== '';
+
+export const getBrowserUrl = () => (vscode.commands.executeCommand('github1s.vscode.get-browser-url') as Promise<string>);

--- a/extensions/github1s/src/util/context.ts
+++ b/extensions/github1s/src/util/context.ts
@@ -21,5 +21,3 @@ export const getOAuthToken = () => {
 };
 
 export const hasValidToken = () => getOAuthToken() !== '';
-
-export const getBrowserUrl = () => (vscode.commands.executeCommand('github1s.vscode.get-browser-url') as Promise<string>);

--- a/extensions/github1s/src/util/git-ref.ts
+++ b/extensions/github1s/src/util/git-ref.ts
@@ -4,7 +4,6 @@
  */
 
 import * as vscode from 'vscode';
-import { getBrowserUrl } from './context';
 import { reuseable } from './func';
 import { getGithubBranches, getGithubTags } from '../api';
 
@@ -28,31 +27,49 @@ export interface RepositoryTag {
 	node_id: string,
 }
 
+let currentOwner = '';
+let currentRepo = '';
 let currentRef = '';
 let repositoryBranches: RepositoryBranch[] = null;
 let repositoryTags: RepositoryTag[] = null;
 
-export const getRepositoryBranches = reuseable((forceUpdate: boolean = false): Promise<RepositoryBranch[]> => {
+// get current browser uri, update `currentOwner` and `currentRepo`
+const getBrowserUri = (): Promise<vscode.Uri> => {
+	return (vscode.commands.executeCommand('github1s.vscode.get-browser-url') as Promise<string>).then(browserUrl => {
+		const browserUri = vscode.Uri.parse(browserUrl);
+		const [owner = 'conwnet', repo = 'github1s'] = browserUri.path.split('/').filter(Boolean);
+		currentOwner = owner;
+		currentRepo = repo;
+		return browserUri;
+	});
+};
+
+const getRepositoryBranchesFromUri = reuseable((uri: vscode.Uri, forceUpdate: boolean = false): Promise<RepositoryBranch[]> => {
 	// use the cached branches if already fetched and not forceUpdate
 	if (repositoryBranches && repositoryBranches.length && !forceUpdate) {
 		return Promise.resolve(repositoryBranches);
 	}
-	return getBrowserUrl().then(url => {
-		const [owner = 'conwnet', repo = 'github1s'] = (vscode.Uri.parse(url).path || '').split('/').filter(Boolean);
-		return getGithubBranches(owner, repo).then(githubBranches => (repositoryBranches = githubBranches));
-	});
+	const [owner = 'conwnet', repo = 'github1s'] = uri.path.split('/').filter(Boolean);
+	return getGithubBranches(owner, repo).then(githubBranches => (repositoryBranches = githubBranches));
 });
 
-export const getRepositoryTags = reuseable((forceUpdate: boolean = false): Promise<RepositoryBranch[]> => {
+export const getRepositoryBranches = reuseable((forceUpdate: boolean = false): Promise<RepositoryBranch[]> => {
+	return getBrowserUri().then(uri => getRepositoryBranchesFromUri(uri, forceUpdate));
+});
+
+const getRepositoryTagsFromUri = reuseable((uri: vscode.Uri, forceUpdate: boolean = false): Promise<RepositoryBranch[]> => {
 	// use the cached tags if already fetched and not forceUpdate
 	if (repositoryTags && repositoryTags.length && !forceUpdate) {
 		return Promise.resolve(repositoryTags);
 	}
-	return getBrowserUrl().then(url => {
-		const [owner = 'conwnet', repo = 'github1s'] = (vscode.Uri.parse(url).path || '').split('/').filter(Boolean);
-		return getGithubTags(owner, repo).then(githubTags => (repositoryTags = githubTags));
-	});
+	const [owner = 'conwnet', repo = 'github1s'] = uri.path.split('/').filter(Boolean);
+	return getGithubTags(owner, repo).then(githubTags => (repositoryTags = githubTags));
 });
+
+export const getRepositoryTags = reuseable((forceUpdate: boolean = false): Promise<RepositoryBranch[]> => {
+	return getBrowserUri().then(uri => getRepositoryTagsFromUri(uri, forceUpdate));
+});
+
 
 // try to find corresponding ref from branchNames or tagNames
 const findMatchedBranchOrTag = (branchOrTagNames: string[], pathParts: string[]): string => {
@@ -68,47 +85,56 @@ const findMatchedBranchOrTag = (branchOrTagNames: string[], pathParts: string[])
 	return null;
 };
 
-
 // get current ref(branch or tag or commit) according current browser url
-export const getCurrentRef = reuseable((forceUpdate: boolean = false): Promise<string> => {
+const getCurrentRefFromUri = reuseable((uri: vscode.Uri, forceUpdate: boolean = false): Promise<string> => {
 	// cache the currentRef if we have already found it and not forceUpdate
 	if (currentRef && !forceUpdate) {
 		return Promise.resolve(currentRef);
 	}
-	return getBrowserUrl().then(url => {
-		// this url should looks like `https://github.com/conwnet/github1s/tree/master/src`
-		const parts = (vscode.Uri.parse(url).path || '').split('/').filter(Boolean);
-		// only support tree/blob type now
-		let maybeBranch = (['tree', 'blob'].includes((parts[2] || '').toLowerCase())) ? parts[3] : '';
+	// this url should looks like `https://github.com/conwnet/github1s/tree/master/src`
+	const parts = uri.path.split('/').filter(Boolean);
+	// only support tree/blob type now
+	let maybeBranch = (['tree', 'blob'].includes((parts[2] || '').toLowerCase())) ? parts[3] : '';
 
-		// if we can't get branch from url, just return `HEAD` which represents `default branch`
-		if (!maybeBranch || maybeBranch.toUpperCase() === 'HEAD') {
-			return 'HEAD';
-		}
+	// if we can't get branch from url, just return `HEAD` which represents `default branch`
+	if (!maybeBranch || maybeBranch.toUpperCase() === 'HEAD') {
+		return Promise.resolve('HEAD');
+	}
 
-		const branchNamesPromise: Promise<string[]> = getRepositoryBranches().then(branches => branches.map(item => item.name));
-		const tagNamesPromise: Promise<string[]> = getRepositoryTags().then(tags => tags.map(item => item.name));
+	const branchNamesPromise: Promise<string[]> = getRepositoryBranchesFromUri(uri).then(branches => branches.map(item => item.name));
+	const tagNamesPromise: Promise<string[]> = getRepositoryTagsFromUri(uri).then(tags => tags.map(item => item.name));
 
-		return branchNamesPromise.then((branchNames: string[]) => {
-			// try to find current ref from repo branches, we needn't wait to tags request ready if can find it here
-			return (currentRef = findMatchedBranchOrTag(branchNames, parts)) || tagNamesPromise.then((tagNames: string[]) => {
-				// try to find current ref from repo tags, it we still can't find it here, just return `maybeBranch`
-				// in this case, the `maybeBranch` could be a `commit hash` (or throw error later)
-				return currentRef = (findMatchedBranchOrTag(tagNames, parts) || maybeBranch);
-			});
+	return branchNamesPromise.then((branchNames: string[]) => {
+		// try to find current ref from repo branches, we needn't wait to tags request ready if can find it here
+		return (currentRef = findMatchedBranchOrTag(branchNames, parts)) || tagNamesPromise.then((tagNames: string[]) => {
+			// try to find current ref from repo tags, it we still can't find it here, just return `maybeBranch`
+			// in this case, the `maybeBranch` could be a `commit hash` (or throw error later)
+			return currentRef = (findMatchedBranchOrTag(tagNames, parts) || maybeBranch);
 		});
 	});
 });
 
-const updateRefInUrl = (url, newRef) => {
-	const uri = vscode.Uri.parse(url);
+export const getCurrentRef = reuseable((forceUpdate: boolean = false) => {
+	return getBrowserUri().then(uri => getCurrentRefFromUri(uri, forceUpdate));
+});
+
+// get the github1s Uri authority from current browser url
+export const getCurrentAuthority = reuseable(() => {
+	if (currentRef) {
+		return Promise.resolve(`${currentOwner}+${currentRepo}+${currentRef}`);
+	}
+	return getCurrentRef().then(ref => `${currentOwner}+${currentRepo}+${ref}`);
+});
+
+
+const updateRefInUri = (uri: vscode.Uri, newRef) => {
 	const parts = (uri.path || '').split('/').filter(Boolean);
-	return uri.with({ path: `${parts[0]}/${parts[1]}/tree/${newRef}` }).toString();
+	return uri.with({ path: `${parts[0]}/${parts[1]}/tree/${newRef}` });
 };
 
 export const changeCurrentRef = (newRef: string): Promise<string> => {
-	return getBrowserUrl().then((url: string) => {
-		vscode.commands.executeCommand('github1s.vscode.replace-browser-url', updateRefInUrl(url, newRef));
+	return getBrowserUri().then((uri: vscode.Uri) => {
+		vscode.commands.executeCommand('github1s.vscode.replace-browser-url', updateRefInUri(uri, newRef).toString());
 		vscode.commands.executeCommand('workbench.action.closeAllGroups');
 		currentRef = newRef;
 		vscode.commands.executeCommand('workbench.files.action.refreshFilesExplorer');

--- a/extensions/github1s/src/util/git-ref.ts
+++ b/extensions/github1s/src/util/git-ref.ts
@@ -1,0 +1,117 @@
+/**
+ * @file github ref(branch or tag) utils
+ * @author netcon
+ */
+
+import * as vscode from 'vscode';
+import { getBrowserUrl } from './context';
+import { reuseable } from './func';
+import { getGithubBranches, getGithubTags } from '../api';
+
+export interface RepositoryBranch {
+	name: string,
+	commit: {
+		sha: string,
+		url: string,
+	},
+	protected?: boolean
+}
+
+export interface RepositoryTag {
+	name: string,
+	commit: {
+		sha: string,
+		url:  string,
+	},
+	zipball_url: string,
+	tarball_url: string,
+	node_id: string,
+}
+
+let currentRef = '';
+let repositoryBranches: RepositoryBranch[] = null;
+let repositoryTags: RepositoryTag[] = null;
+
+export const getRepositoryBranches = reuseable((forceUpdate: boolean = false): Promise<RepositoryBranch[]> => {
+	// use the cached branches if already fetched and not forceUpdate
+	if (repositoryBranches && repositoryBranches.length && !forceUpdate) {
+		return Promise.resolve(repositoryBranches);
+	}
+	return getBrowserUrl().then(url => {
+		const [owner = 'conwnet', repo = 'github1s'] = (vscode.Uri.parse(url).path || '').split('/').filter(Boolean);
+		return getGithubBranches(owner, repo).then(githubBranches => (repositoryBranches = githubBranches));
+	});
+});
+
+export const getRepositoryTags = reuseable((forceUpdate: boolean = false): Promise<RepositoryBranch[]> => {
+	// use the cached tags if already fetched and not forceUpdate
+	if (repositoryTags && repositoryTags.length && !forceUpdate) {
+		return Promise.resolve(repositoryTags);
+	}
+	return getBrowserUrl().then(url => {
+		const [owner = 'conwnet', repo = 'github1s'] = (vscode.Uri.parse(url).path || '').split('/').filter(Boolean);
+		return getGithubTags(owner, repo).then(githubTags => (repositoryTags = githubTags));
+	});
+});
+
+// try to find corresponding ref from branchNames or tagNames
+const findMatchedBranchOrTag = (branchOrTagNames: string[], pathParts: string[]): string => {
+	let partIndex = 3;
+	let maybeBranch = pathParts[partIndex];
+
+	while (branchOrTagNames.find(item => item.startsWith(maybeBranch))) {
+		if (branchOrTagNames.includes(maybeBranch)) {
+			return maybeBranch;
+		}
+		maybeBranch = `${maybeBranch}/${pathParts[++partIndex]}`;
+	}
+	return null;
+};
+
+
+// get current ref(branch or tag or commit) according current browser url
+export const getCurrentRef = reuseable((forceUpdate: boolean = false): Promise<string> => {
+	// cache the currentRef if we have already found it and not forceUpdate
+	if (currentRef && !forceUpdate) {
+		return Promise.resolve(currentRef);
+	}
+	return getBrowserUrl().then(url => {
+		// this url should looks like `https://github.com/conwnet/github1s/tree/master/src`
+		const parts = (vscode.Uri.parse(url).path || '').split('/').filter(Boolean);
+		// only support tree/blob type now
+		let maybeBranch = (['tree', 'blob'].includes((parts[2] || '').toLowerCase())) ? parts[3] : '';
+
+		// if we can't get branch from url, just return `HEAD` which represents `default branch`
+		if (!maybeBranch || maybeBranch.toUpperCase() === 'HEAD') {
+			return 'HEAD';
+		}
+
+		const branchNamesPromise: Promise<string[]> = getRepositoryBranches().then(branches => branches.map(item => item.name));
+		const tagNamesPromise: Promise<string[]> = getRepositoryTags().then(tags => tags.map(item => item.name));
+
+		return branchNamesPromise.then((branchNames: string[]) => {
+			// try to find current ref from repo branches, we needn't wait to tags request ready if can find it here
+			return (currentRef = findMatchedBranchOrTag(branchNames, parts)) || tagNamesPromise.then((tagNames: string[]) => {
+				// try to find current ref from repo tags, it we still can't find it here, just return `maybeBranch`
+				// in this case, the `maybeBranch` could be a `commit hash` (or throw error later)
+				return currentRef = (findMatchedBranchOrTag(tagNames, parts) || maybeBranch);
+			});
+		});
+	});
+});
+
+const updateRefInUrl = (url, newRef) => {
+	const uri = vscode.Uri.parse(url);
+	const parts = (uri.path || '').split('/').filter(Boolean);
+	return uri.with({ path: `${parts[0]}/${parts[1]}/tree/${newRef}` }).toString();
+};
+
+export const changeCurrentRef = (newRef: string): Promise<string> => {
+	return getBrowserUrl().then((url: string) => {
+		vscode.commands.executeCommand('github1s.vscode.replace-browser-url', updateRefInUrl(url, newRef));
+		vscode.commands.executeCommand('workbench.action.closeAllGroups');
+		currentRef = newRef;
+		vscode.commands.executeCommand('workbench.files.action.refreshFilesExplorer');
+		return newRef;
+	});
+};

--- a/extensions/github1s/src/util/index.ts
+++ b/extensions/github1s/src/util/index.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 export { fetch } from './fetch';
 export { reuseable, throttle } from './func';
 export { getExtensionContext, setExtensionContext, hasValidToken, getOAuthToken } from './context';
-export { getCurrentRef, getRepositoryBranches, getRepositoryTags, changeCurrentRef } from './git-ref';
+export { getCurrentRef, getCurrentAuthority, getRepositoryBranches, getRepositoryTags, changeCurrentRef } from './git-ref';
 
 export const noop = () => { };
 

--- a/extensions/github1s/src/util/index.ts
+++ b/extensions/github1s/src/util/index.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 export { fetch } from './fetch';
 export { reuseable, throttle } from './func';
 export { getExtensionContext, setExtensionContext, hasValidToken, getOAuthToken } from './context';
+export { getCurrentRef, getRepositoryBranches, getRepositoryTags, changeCurrentRef } from './git-ref';
 
 export const noop = () => { };
 
@@ -65,35 +66,4 @@ export const getWebviewOptions = (extensionUri: vscode.Uri): vscode.WebviewOptio
 		// And restrict the webview to only loading content from our extension's `assets` directory.
 		localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'assets')]
 	};
-};
-
-export const splitPathByBranchName = (pathname: string, branchNames: string[]) => {
-	const branchNameSet = new Set([...branchNames, 'HEAD']);
-	const parts = pathname.split('/').filter(Boolean).slice(1);
-	if (parts.length < 1) {
-		return ['HEAD', '/'];
-	}
-	let branch;
-	for (const part of parts) {
-		branch = branch ? `${branch}/${part}` : part;
-		if (branchNameSet.has(branch)) {
-			return [
-				branch,
-				parts.join('/').substring(branch.length)
-			];
-		}
-	}
-	// commit id based URL
-	return [parts[0], '/' + parts.slice(1).join('')];
-};
-
-export const getNormalizedPath = (path, branch) => {
-	/**
-	 * Handle the inital path since there is no way to determine the branch name
-	 * before the workbench (extension) loaded.
-	 */
-	if (path.startsWith('/tree') || path.startsWith('/blob')) {
-		return path.substring(7 + branch.length);
-	}
-	return path;
 };

--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -386,7 +386,7 @@ class WindowIndicator implements IWindowIndicator {
 			}
 
 			if (uri?.scheme === 'github1s') {
-				[repositoryOwner, repositoryName] = uri.authority.split('+');
+				[repositoryOwner = 'conwnet', repositoryName = 'github1s'] = URI.parse(getBrowserUrl()).path.split('/').filter(Boolean);
 			}
 		}
 
@@ -407,7 +407,8 @@ class WindowIndicator implements IWindowIndicator {
 (function () {
 	const [repoOwner = 'conwnet', repoName = 'github1s'] = (URI.parse(window.location.href).path || '').split('/').filter(Boolean);
 	const config: IWorkbenchConstructionOptions & { folderUri?: UriComponents, workspaceUri?: UriComponents } = {
-		folderUri: URI.from({ scheme: "github1s", path: '/', authority: `${repoOwner}+${repoName}` }),
+		// the empty authority means github1s should get it from `window.location.href`
+		folderUri: URI.from({ scheme: "github1s", path: '/', authority: '' }),
 		staticExtensions: [],
 		enableSyncByDefault: false,
 		webWorkerExtensionHostIframeSrc: document.getElementById('vscode-extension-host-iframe-src')?.getAttribute('data-settings') as string,

--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -18,8 +18,14 @@ import { localize } from 'vs/nls';
 import { Schemas } from 'vs/base/common/network';
 import product from 'vs/platform/product/common/product';
 import { parseLogLevel } from 'vs/platform/log/common/log';
-import { parseGitHubUrl } from 'vs/github1s/util';
+import { getBrowserUrl, replaceBrowserUrl } from 'vs/github1s/util';
 import { renderNotification } from 'vs/github1s/notification';
+
+// custom vs code commands defined by github1s
+const getGitHub1sCustomCommands: () => ({id: string, handler: (...args: any[]) => unknown }[]) = () => [
+	{ id: 'github1s.vscode.get-browser-url', handler: getBrowserUrl },
+	{ id: 'github1s.vscode.replace-browser-url', handler: replaceBrowserUrl },
+];
 
 function doCreateUri(path: string, queryValues: Map<string, string>): URI {
 	let query: string | undefined = undefined;
@@ -399,17 +405,13 @@ class WindowIndicator implements IWindowIndicator {
 }
 
 (function () {
-	const route = parseGitHubUrl(window.location.href);
+	const [repoOwner = 'conwnet', repoName = 'github1s'] = (URI.parse(window.location.href).path || '').split('/').filter(Boolean);
 	const config: IWorkbenchConstructionOptions & { folderUri?: UriComponents, workspaceUri?: UriComponents } = {
-		/**
-		 * We couldn't figure out the correct branch here since branch might has `/` i.e. `feat/new-feat-1`.
-		 * So we have to use the `route.path` in authority and figure out branch in github1s extension.
-		 */
-		folderUri: URI.from({ scheme: "github1s", path: '/', authority: `${route.owner}+${route.repo}+${route.path}` }),
+		folderUri: URI.from({ scheme: "github1s", path: '/', authority: `${repoOwner}+${repoName}` }),
 		staticExtensions: [],
 		enableSyncByDefault: false,
 		webWorkerExtensionHostIframeSrc: document.getElementById('vscode-extension-host-iframe-src')?.getAttribute('data-settings') as string,
-	};
+};
 
 	// Revive static extension locations
 	if (Array.isArray(config.staticExtensions)) {
@@ -478,7 +480,7 @@ class WindowIndicator implements IWindowIndicator {
 
 	// Home Indicator
 	const homeIndicator: IHomeIndicator = {
-		href: `https://github.com/${route.owner}/${route.repo}`,
+		href: `https://github.com/${repoOwner}/${repoName}`,
 		icon: 'github',
 		title: localize('home', "Home")
 	};
@@ -528,6 +530,7 @@ class WindowIndicator implements IWindowIndicator {
 	// Finally create workbench
 	create(document.body, {
 		...config,
+		commands: getGitHub1sCustomCommands(),
 		logLevel: logLevel ? parseLogLevel(logLevel) : undefined,
 		settingsSyncOptions,
 		homeIndicator,

--- a/src/vs/github1s/util.ts
+++ b/src/vs/github1s/util.ts
@@ -3,65 +3,12 @@
  * @autor netcon
  */
 
-interface GitHubRouteState {
-	owner: string;
-	repo: string;
-	type: string;
-	branch?: string;
-	path: string;
-	search: string;
-	hash: string;
-}
-
-export const parseGitHubUrl = (url: string): GitHubRouteState => {
-	const urlObj = new window.URL(url);
-	const parts = urlObj.pathname.split(/\/|%2F/g).filter(Boolean);
-	const hasFileType = ['tree', 'blob'].includes(parts[2]);
-
-	return {
-		owner: parts[0] || 'conwnet',
-		repo: parts[1] || 'github1s',
-		type: (hasFileType ? parts[2] : 'tree').toLowerCase(),
-		path: '/' + parts.slice(2).join('/'),
-		search: urlObj.search || '',
-		hash: urlObj.hash || ''
-	};
+export const getBrowserUrl = (): string => {
+	return window.location.href;
 };
 
-export const splitPathByBranchName = (pathname: string, branchNames: string[]) => {
-	const branchNameSet = new Set([...branchNames, 'HEAD']);
-	const parts = pathname.split('/').filter(Boolean).slice(3);
-	if (parts.length < 1) {
-		return ['HEAD', '/'];
+export const replaceBrowserUrl = (url: string) => {
+	if (window.history.replaceState) {
+		window.history.replaceState(null, '', url);
 	}
-	let branch;
-	for (const part of parts) {
-		branch = branch ? `${branch}/${part}` : part;
-		if (branchNameSet.has(branch)) {
-			return [
-				branch,
-				parts.join('/').substring(branch.length)
-			];
-		}
-	}
-	// commit id based URL
-	return [parts[0], '/' + parts.slice(1).join('')];
-};
-
-export const parseGitHubUrlWithBranchNames = (url: string, branchNames: string[]): GitHubRouteState => {
-	const urlObj = new window.URL(url);
-	const parts = urlObj.pathname.split(/\/|%2F/g).filter(Boolean);
-	const hasBranchName = ['tree', 'blob'].includes(parts[2]);
-
-	const [branch, path] = splitPathByBranchName(urlObj.pathname, branchNames);
-
-	return {
-		owner: parts[0] || 'conwnet',
-		repo: parts[1] || 'github1s',
-		type: (hasBranchName ? parts[2] : 'tree').toLowerCase(),
-		branch,
-		path,
-		search: urlObj.search || '',
-		hash: urlObj.hash || ''
-	};
 };

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -291,7 +291,7 @@ export class TitlebarPart extends Part implements ITitleService {
 		const remoteName = this.labelService.getHostLabel(Schemas.vscodeRemote, this.environmentService.remoteAuthority);
 		const separator = this.configurationService.getValue<string>('window.titleSeparator');
 		const titleTemplate = this.configurationService.getValue<string>('window.title');
-	const [owner, repo] = (folderName || '').split('+');
+		const [owner = 'conwnet', repo = 'github1s'] = URI.parse(window.location.href).path.split('/').filter(Boolean);
 
 		return template(titleTemplate, {
 			activeEditorShort,

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -231,9 +231,9 @@ export class ExplorerView extends ViewPane {
 			const title = workspace.folders.map(folder => folder.name).join();
 			// modify by github1s, set file explorer title with `${route.owner}/${route.repo}`
 			const currentFolderUri = workspace.folders?.[0].uri;
-			const textContent = (currentFolderUri && currentFolderUri.scheme === 'github1s' && currentFolderUri.authority)
-				? currentFolderUri.authority.split('+').slice(0, 2).join('/')
-	: this.name;
+			const textContent = (currentFolderUri && currentFolderUri.scheme === 'github1s')
+				? URI.parse(window.location.href).path.split('/').filter(Boolean).slice(0, 2).join('/') || 'conwnet/github1s'
+				: this.name;
 			titleElement.textContent = textContent;
 			titleElement.title = title;
 			titleElement.setAttribute('aria-label', nls.localize('explorerSection', "Explorer Section: {0}", this.name));

--- a/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -47,11 +47,21 @@ import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { buttonBackground, buttonHoverBackground, welcomePageBackground } from 'vs/workbench/contrib/welcome/page/browser/welcomePageColors';
-import { parseGitHubUrl, parseGitHubUrlWithBranchNames } from 'vs/github1s/util';
+import { replaceBrowserUrl } from 'vs/github1s/util';
 
 const configurationKey = 'workbench.startupEditor';
 const oldConfigurationKey = 'workbench.welcome.enabled';
 const telemetryFrom = 'welcomePage';
+
+const getCurrentFileState = (ref: string): { owner: string, repo: string, type: string, path: string } => {
+	const uri = URI.parse(window.location.href);
+	const [owner = 'conwnet', repo = 'github1s', type, ...otherParts] = (uri.path || '').split('/').filter(Boolean);
+	const refAndFilePath = otherParts.join('/');
+	if (!['tree', 'blob'].includes(type) || !refAndFilePath.startsWith(ref)) {
+		return { owner, repo, type: 'tree', path: '/' };
+	}
+	return { owner, repo, type, path: refAndFilePath.slice(ref.length) || '/' };
+};
 
 export class WelcomePageContribution implements IWorkbenchContribution {
 
@@ -69,53 +79,53 @@ export class WelcomePageContribution implements IWorkbenchContribution {
 
 		const enabled = isWelcomePageEnabled(configurationService, contextService);
 		if (enabled && lifecycleService.startupKind !== StartupKind.ReloadedWindow) {
-			const route = parseGitHubUrl(window.location.href);
 			const activeResource = editorService.activeEditor?.resource;
-			if (route.path !== '/' && (!activeResource || activeResource.scheme === 'github1s' || activeResource.path !== route.path)) {
-				const file = URI.from({ scheme: 'github1s', authority: `${route.owner}+${route.repo}+${route.path}`, path: route.path });
-				fileService.resolve(file)
-					.then(() => this.commandService.executeCommand(route.type === 'tree' ? 'revealInExplorer' : 'vscode.open', file))
-					.then(() => this.registerListeners(), () => this.registerListeners());
-				return;
-			}
+			getCurrentGithubRef(commandService).then((currentRef: string) => {
+				const fileState = getCurrentFileState(currentRef);
+				if (fileState.path !== '/' && (!activeResource || activeResource.scheme !== 'github1s' || activeResource.path !== fileState.path)) {
+					const currentFileUri = URI.from({ scheme: 'github1s', authority: `${fileState.owner}+${fileState.repo}`, path: fileState.path });
+					fileService.resolve(currentFileUri)
+						.then(() => this.commandService.executeCommand(fileState.type === 'tree' ? 'revealInExplorer' : 'vscode.open', currentFileUri))
+						.then(() => this.registerListeners(), () => this.registerListeners());
+					return;
+				}
+				backupFileService.hasBackups().then(hasBackups => {
+					// Open the welcome even if we opened a set of default editors
+					if ((!editorService.activeEditor || layoutService.openedDefaultEditors) && !hasBackups) {
+						return Promise.all(contextService.getWorkspace().folders.map(folder => {
+							const folderUri = folder.uri;
+							return fileService.resolve(folderUri)
+								.then(folder => {
+									const files = folder.children ? folder.children.map(child => child.name).sort() : [];
+									const file = files.find(file => file.toLowerCase() === 'readme.md') || files.find(file => file.toLowerCase().startsWith('readme'));
 
-			backupFileService.hasBackups().then(hasBackups => {
-				// Open the welcome even if we opened a set of default editors
-				if ((!editorService.activeEditor || layoutService.openedDefaultEditors) && !hasBackups) {
-					return Promise.all(contextService.getWorkspace().folders.map(folder => {
-						const folderUri = folder.uri;
-						return fileService.resolve(folderUri)
-							.then(folder => {
-								const files = folder.children ? folder.children.map(child => child.name).sort() : [];
-								const file = files.find(file => file.toLowerCase() === 'readme.md') || files.find(file => file.toLowerCase().startsWith('readme'));
-
-								if (file) {
-									return joinPath(folderUri, file);
+									if (file) {
+										return joinPath(folderUri, file);
+									}
+									return undefined;
+								}, onUnexpectedError);
+						})).then(arrays.coalesce)
+							.then<any>(readmes => {
+								if (!editorService.activeEditor) {
+									if (readmes.length) {
+										const isMarkDown = (readme: URI) => readme.path.toLowerCase().endsWith('.md');
+										return Promise.all([
+											this.commandService.executeCommand('markdown.showPreview', null, readmes.filter(isMarkDown), { locked: true }),
+											editorService.openEditors(readmes.filter(readme => !isMarkDown(readme))
+												.map(readme => ({ resource: readme }))),
+										]);
+									} else {
+										return instantiationService.createInstance(WelcomePage).openEditor();
+									}
 								}
 								return undefined;
-							}, onUnexpectedError);
-					})).then(arrays.coalesce)
-						.then<any>(readmes => {
-							if (!editorService.activeEditor) {
-								if (readmes.length) {
-									const isMarkDown = (readme: URI) => readme.path.toLowerCase().endsWith('.md');
-									return Promise.all([
-										this.commandService.executeCommand('markdown.showPreview', null, readmes.filter(isMarkDown), { locked: true }),
-										editorService.openEditors(readmes.filter(readme => !isMarkDown(readme))
-											.map(readme => ({ resource: readme }))),
-									]);
-								} else {
-									return instantiationService.createInstance(WelcomePage).openEditor();
-								}
-							}
-							return undefined;
-						});
-				}
-				return undefined;
-			}).then(undefined, onUnexpectedError).then(() => this.registerListeners(), () => this.registerListeners());
+							});
+					}
+					return undefined;
+				}).then(undefined, onUnexpectedError).then(() => this.registerListeners(), () => this.registerListeners());
+			});
 		}
 	}
-
 
 	private getGitHubFilePathOrEmpty(uri?: URI): string {
 		if (!uri || !uri.path || uri.scheme !== 'github1s') {
@@ -125,20 +135,16 @@ export class WelcomePageContribution implements IWorkbenchContribution {
 	}
 
 	private doUpdateWindowUrl(): void {
-		getGitHubBranches(this.commandService, window.location.href).then(
-			(branchNames) => {
-				const state = parseGitHubUrlWithBranchNames(window.location.href, branchNames);
-				const editor = this.editorService.activeEditor;
-				const filePath = this.getGitHubFilePathOrEmpty(editor?.resource);
-				// if no file opened and the branch is HEAD current, only retain owner and repo in url
-				const windowUrl = !filePath && state.branch === 'HEAD'
-					? `/${state.owner}/${state.repo}`
-					: `/${state.owner}/${state.repo}/${filePath ? 'blob' : 'tree'}/${state.branch}${filePath}`;
-				if (window.history.replaceState) {
-					window.history.replaceState(null, '', windowUrl);
-				}
-			}
-		);
+		getCurrentGithubRef(this.commandService).then(currentRef => {
+			const state = getCurrentFileState(currentRef);
+			const editor = this.editorService.activeEditor;
+			const filePath = this.getGitHubFilePathOrEmpty(editor?.resource);
+			// if no file opened and the branch is HEAD current, only retain owner and repo in url
+			const windowUrl = !filePath && currentRef.toUpperCase() === 'HEAD'
+				? `/${state.owner}/${state.repo}`
+				: `/${state.owner}/${state.repo}/${filePath ? 'blob' : 'tree'}/${currentRef}${filePath}`;
+			replaceBrowserUrl(windowUrl);
+		});
 	}
 
 	private registerListeners() {
@@ -157,8 +163,8 @@ function isWelcomePageEnabled(configurationService: IConfigurationService, conte
 	return startupEditor.value === 'welcomePage' || startupEditor.value === 'gettingStarted' || startupEditor.value === 'readme' || startupEditor.value === 'welcomePageInEmptyWorkbench' && contextService.getWorkbenchState() === WorkbenchState.EMPTY;
 }
 
-function getGitHubBranches(commandService: ICommandService, url: string) {
-	return commandService.executeCommand('github1s.get-github-branches', url);
+function getCurrentGithubRef(commandService: ICommandService): Promise<string> {
+	return commandService.executeCommand('github1s.get-current-ref') as Promise<string>;
 }
 
 export class WelcomePageAction extends Action {


### PR DESCRIPTION
1. change the URI authority as format `{owner}/{repo}` (the `github codespaces` does the samething), move the git branches logic into github1s extension
2. add github tags support (the parts[3] in url also canbe a tag)
3. allow to switch branch and tag

There is another problems, github REST API only return 100 branches(or tags) per request and not supoort search, I only fetch up to 200 branches now, if a repository is more the 200 branches, an error can be appeared
